### PR TITLE
Fix Dike being able to be built in Coastal or Rivers

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -363,8 +363,7 @@
 		"cost": 180,
 		"maintenance": 1,
 		"uniques": [
-			"Must be on [River]",
-			"Only available <in [Coastal] cities>",
+			"Unavailable <in tiles without [Coastal]> <in tiles without [River]>",
 			"[+1 Production] from [River] tiles [in this city]",
 			"[+1 Production] from [Water] tiles [in this city]"
 		],


### PR DESCRIPTION
Makes Dikes only available when on Coasts or on Rivers...

Fixes yairm210/Civ-IV#91 
https://github.com/yairm210/Civ-IV/issues/91

Had to flip the logic condition.
